### PR TITLE
Use maven container to wrap smoke test stage.

### DIFF
--- a/vars/smokeTest.groovy
+++ b/vars/smokeTest.groovy
@@ -1,9 +1,11 @@
 def call(String appUrl="") {
-    echo 'Perform smoke test for system viability'
-    healthCheck = sh(script: "curl ${appUrl}/health-check", returnStatus: true)
-    if (healthCheck != 0) {
-        echo "Error found running the smoke test."
-        currentBuild.result = 'FAILURE'
-        throw err
+    container('maven') {
+        echo 'Perform smoke test for system viability'
+        healthCheck = sh(script: "curl ${appUrl}health-check", returnStatus: true)
+        if (healthCheck != 0) {
+            echo "Error found running the smoke test."
+            currentBuild.result = 'FAILURE'
+            throw err
+        }
     }
 }


### PR DESCRIPTION
Updated jenkins lost curl on the base jnlp container, so we need to wrap this stage in a container that has it installed.